### PR TITLE
Fix jitter on affordability slider

### DIFF
--- a/src/components/finance-navigator/AffordabilityCard.tsx
+++ b/src/components/finance-navigator/AffordabilityCard.tsx
@@ -50,7 +50,9 @@ export function AffordabilityCard() {
             </Label>
             <div className="mt-4 flex items-center gap-4">
               <span className="text-4xl font-bold text-primary font-headline tracking-tight">
-                <AnimatedNumber value={localBudget} formatter={(val) => formatCurrency(val)} />
+                <span className="inline-block min-w-[7ch] tabular-nums">
+                  <AnimatedNumber value={localBudget} formatter={(val) => formatCurrency(val)} />
+                </span>
               </span>
               <Slider
                 id="monthly-budget"


### PR DESCRIPTION
## Summary
- wrap the animated budget value in a fixed-width, tabular-numeral span to prevent width changes during animation

## Testing
- `npm run lint` *(fails: command prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68f4bcbfd808832c930c2d47ffa5ae03