### PR TITLE
Improve quiz results layout and Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -81,6 +81,12 @@ service cloud.firestore {
       allow update, delete: if isExistingOwner(resource.data.dealerId);
       allow read: if true;
       allow write: if false;
+
+      match /history/{historyId} {
+        allow get, list: if canAccessFinancialOffer(financialOfferId);
+        allow create: if canAccessFinancialOffer(financialOfferId);
+        allow update, delete: if false;
+      }
     }
 
     /**
@@ -218,11 +224,15 @@ service cloud.firestore {
      * @principle Access control based on FinancialOffer ownership.
      */
     match /negotiationThreads/{negotiationThreadId} {
-       allow get: if get(/databases/$(database)/documents/financialOffers/$(resource.data.financialOfferId)).data.dealerId == request.auth.uid;
-        allow list: if true;
-        allow create: if isSignedIn() && request.resource.data.financialOfferId != null;
-        allow update: if false;
-        allow delete: if false;
+      allow get: if canAccessFinancialOffer(resource.data.financialOfferId);
+      allow list: if isSignedIn();
+      allow create: if isSignedIn() && request.resource.data.financialOfferId != null;
+      allow update: if
+        isSignedIn() &&
+        resource != null &&
+        request.resource.data.financialOfferId == resource.data.financialOfferId &&
+        request.resource.data.dealerId == resource.data.dealerId;
+      allow delete: if false;
     }
 
     /**
@@ -236,11 +246,16 @@ service cloud.firestore {
      * @principle Access control mirrors the parent thread.
      */
     match /negotiationThreads/{negotiationThreadId}/messages/{messageId} {
-        allow get: if get(/databases/$(database)/documents/negotiationThreads/$(negotiationThreadId)).data.financialOfferId != null && get(/databases/$(database)/documents/financialOffers/$(get(/databases/$(database)/documents/negotiationThreads/$(negotiationThreadId)).data.financialOfferId)).data.dealerId == request.auth.uid;
-        allow list: if true;
-        allow create: if isSignedIn() && request.resource.data.negotiationThreadId == negotiationThreadId;
-        allow update: if false;
-        allow delete: if false;
+      allow get: if canAccessFinancialOffer(
+        get(/databases/$(database)/documents/negotiationThreads/$(negotiationThreadId)).data.financialOfferId
+      );
+      allow list: if isSignedIn();
+      allow create: if
+        isSignedIn() &&
+        request.resource.data.negotiationThreadId == negotiationThreadId &&
+        request.resource.data.authorId == request.auth.uid;
+      allow update: if false;
+      allow delete: if false;
     }
 
     /**
@@ -305,6 +320,13 @@ service cloud.firestore {
 
     function isExistingOwner(userId) {
       return isSignedIn() && isOwner(userId) && resource != null;
+    }
+
+    function canAccessFinancialOffer(financialOfferId) {
+      return
+        isSignedIn() &&
+        financialOfferId != null &&
+        get(/databases/$(database)/documents/financialOffers/$(financialOfferId)).data.dealerId == request.auth.uid;
     }
   }
 }

--- a/src/components/checkout/PrequalDialog.tsx
+++ b/src/components/checkout/PrequalDialog.tsx
@@ -89,17 +89,22 @@ export function PrequalDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl overflow-hidden">
-        <DialogHeader>
-          <DialogTitle>Get prequalified</DialogTitle>
-          <DialogDescription>
-            Provide a few details so we can tee up a personalized credit pre-qualification. This will initiate a soft pull only.
-          </DialogDescription>
-        </DialogHeader>
-        <Form {...form}>
-          <form className="space-y-4" onSubmit={form.handleSubmit(handleSubmit)} noValidate>
-            <ScrollArea className="max-h-[60vh] pr-4">
-              <div className="space-y-6 pb-4">
+      <DialogContent className="sm:max-w-3xl max-h-[85vh] overflow-hidden p-0">
+        <div className="flex h-full flex-col">
+          <DialogHeader className="space-y-2 px-6 pt-6">
+            <DialogTitle>Get prequalified</DialogTitle>
+            <DialogDescription>
+              Provide a few details so we can tee up a personalized credit pre-qualification. This will initiate a soft pull only.
+            </DialogDescription>
+          </DialogHeader>
+          <Form {...form}>
+            <form
+              className="flex flex-1 flex-col gap-4 px-6 pb-6"
+              onSubmit={form.handleSubmit(handleSubmit)}
+              noValidate
+            >
+              <ScrollArea className="flex-1 -mr-4 pr-4">
+                <div className="space-y-6 pb-4">
                 <div className="grid gap-4 md:grid-cols-2">
                   <FormField
                     control={form.control}
@@ -314,28 +319,34 @@ export function PrequalDialog({
                   )}
                 />
               </div>
-            </ScrollArea>
+              </ScrollArea>
 
-            <p className="text-xs text-muted-foreground">
-              By submitting this form you acknowledge that we will acquire your credit report for pre-qualification.
-            </p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                By submitting this form you acknowledge that we will acquire your credit report for pre-qualification.
+              </p>
 
-            <div className="flex justify-end gap-2">
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? (
-                  <span className="flex items-center gap-2">
-                    <Loader2 className="h-4 w-4 animate-spin" /> Submitting…
-                  </span>
-                ) : (
-                  'Submit and run soft pull'
-                )}
-              </Button>
-            </div>
-          </form>
-        </Form>
+              <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-end sm:gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                  className="sm:min-w-[120px]"
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isSubmitting} className="sm:min-w-[180px]">
+                  {isSubmitting ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Submitting…
+                    </span>
+                  ) : (
+                    'Submit and run soft pull'
+                  )}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/model-match-quiz/QuizResults.tsx
+++ b/src/components/model-match-quiz/QuizResults.tsx
@@ -29,7 +29,7 @@ export function QuizResults({ results, onSelectVehicle, onRestart }: QuizResults
           <Card key={model.modelName} className="flex flex-col overflow-hidden hover:shadow-2xl transition-shadow duration-300 group">
             <CardHeader className="p-0">
                 <div className='bg-primary/10 p-4'>
-                    <p className="text-primary font-semibold text-center">"{model.rationale}"</p>
+                    <p className="text-primary font-semibold text-center">{model.rationale}</p>
                 </div>
               <div className="relative h-48 w-full">
                 <Image


### PR DESCRIPTION
## Summary
- remove unnecessary quotation marks around quiz recommendation rationale text for a cleaner presentation
- refactor the prequalification dialog layout so the form content scrolls within the existing panel and action buttons remain accessible
- expand Firestore rules to permit dealer history writes and negotiation thread updates while validating message authorship

## Testing
- npm run lint *(fails: interactive Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68f4c236a88c832ca33dd5aad051bcac