### PR TITLE
Adjust Firestore rules for customer negotiation access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -81,6 +81,12 @@ service cloud.firestore {
       allow update, delete: if isExistingOwner(resource.data.dealerId);
       allow read: if true;
       allow write: if false;
+
+      match /history/{historyId} {
+        allow get, list: if isDealerForFinancialOffer(financialOfferId);
+        allow create: if isDealerForFinancialOffer(financialOfferId);
+        allow update, delete: if false;
+      }
     }
 
     /**
@@ -218,11 +224,53 @@ service cloud.firestore {
      * @principle Access control based on FinancialOffer ownership.
      */
     match /negotiationThreads/{negotiationThreadId} {
-       allow get: if get(/databases/$(database)/documents/financialOffers/$(resource.data.financialOfferId)).data.dealerId == request.auth.uid;
-        allow list: if true;
-        allow create: if isSignedIn() && request.resource.data.financialOfferId != null;
-        allow update: if false;
-        allow delete: if false;
+      allow get: if resource != null && canAccessFinancialOffer(resource.data.financialOfferId);
+      allow list: if false;
+      allow create: if
+        canAccessFinancialOffer(request.resource.data.financialOfferId) &&
+        request.resource.data.keys().hasOnly([
+          'financialOfferId',
+          'dealerId',
+          'status',
+          'createdAt',
+          'updatedAt',
+          'lastMessagePreview',
+          'customerId',
+        ]) &&
+        request.resource.data.financialOfferId == negotiationThreadId &&
+        matchesOfferDealer(request.resource.data.financialOfferId, request.resource.data.dealerId) &&
+        request.resource.data.status in ['open', 'accepted', 'closed'];
+      allow update: if
+        resource != null &&
+        canAccessFinancialOffer(resource.data.financialOfferId) &&
+        matchesOfferDealer(resource.data.financialOfferId, resource.data.dealerId) &&
+        request.resource.data.keys().hasOnly([
+          'financialOfferId',
+          'dealerId',
+          'status',
+          'createdAt',
+          'updatedAt',
+          'lastMessagePreview',
+          'customerId',
+        ]) &&
+        (
+          !request.resource.data.keys().hasAny(['financialOfferId']) ||
+          request.resource.data.financialOfferId == resource.data.financialOfferId
+        ) &&
+        (
+          !request.resource.data.keys().hasAny(['dealerId']) ||
+          request.resource.data.dealerId == resource.data.dealerId
+        ) &&
+        (
+          !request.resource.data.keys().hasAny(['status']) ||
+          request.resource.data.status in ['open', 'accepted', 'closed']
+        ) &&
+        (
+          !request.resource.data.keys().hasAny(['customerId']) ||
+          resource.data.customerId == null ||
+          request.resource.data.customerId == resource.data.customerId
+        );
+      allow delete: if false;
     }
 
     /**
@@ -236,11 +284,47 @@ service cloud.firestore {
      * @principle Access control mirrors the parent thread.
      */
     match /negotiationThreads/{negotiationThreadId}/messages/{messageId} {
-        allow get: if get(/databases/$(database)/documents/negotiationThreads/$(negotiationThreadId)).data.financialOfferId != null && get(/databases/$(database)/documents/financialOffers/$(get(/databases/$(database)/documents/negotiationThreads/$(negotiationThreadId)).data.financialOfferId)).data.dealerId == request.auth.uid;
-        allow list: if true;
-        allow create: if isSignedIn() && request.resource.data.negotiationThreadId == negotiationThreadId;
-        allow update: if false;
-        allow delete: if false;
+      allow get: if canAccessNegotiationThread(negotiationThreadId);
+      allow list: if canAccessNegotiationThread(negotiationThreadId);
+      allow create: if
+        canAccessNegotiationThread(negotiationThreadId) &&
+        request.resource.data.keys().hasOnly([
+          'negotiationThreadId',
+          'authorId',
+          'authorRole',
+          'content',
+          'reasonCode',
+          'counterProposal',
+          'createdAt',
+        ]) &&
+        request.resource.data.negotiationThreadId == negotiationThreadId &&
+        request.resource.data.authorRole in ['dealer', 'customer'] &&
+        request.resource.data.content is string &&
+        request.resource.data.content.size() > 0 &&
+        isValidMessageAuthor(negotiationThreadId) &&
+        (
+          !request.resource.data.keys().hasAny(['reasonCode']) ||
+          request.resource.data.reasonCode in [
+            'TERM_EXTENSION',
+            'MILEAGE_ADJUSTMENT',
+            'DOWN_PAYMENT_ADJUSTMENT',
+            'CUSTOM',
+          ]
+        ) &&
+        (
+          !request.resource.data.keys().hasAny(['counterProposal']) ||
+          (
+            request.resource.data.counterProposal is map &&
+            request.resource.data.counterProposal.keys().hasOnly([
+              'termMonths',
+              'mileageAllowance',
+              'downPayment',
+              'estimatedPayment',
+            ])
+          )
+        );
+      allow update: if false;
+      allow delete: if false;
     }
 
     /**
@@ -305,6 +389,68 @@ service cloud.firestore {
 
     function isExistingOwner(userId) {
       return isSignedIn() && isOwner(userId) && resource != null;
+    }
+
+    function getFinancialOfferDocument(financialOfferId) {
+      return get(/databases/$(database)/documents/financialOffers/$(financialOfferId));
+    }
+
+    function isPublishedFinancialOffer(financialOfferId) {
+      return financialOfferId != null && getFinancialOfferDocument(financialOfferId).data.status == 'published';
+    }
+
+    function isDealerForFinancialOffer(financialOfferId) {
+      return
+        request.auth != null &&
+        financialOfferId != null &&
+        getFinancialOfferDocument(financialOfferId).data.dealerId == request.auth.uid;
+    }
+
+    function matchesOfferDealer(financialOfferId, dealerId) {
+      return
+        financialOfferId != null &&
+        dealerId != null &&
+        getFinancialOfferDocument(financialOfferId).data.dealerId == dealerId;
+    }
+
+    function canAccessFinancialOffer(financialOfferId) {
+      return financialOfferId != null && (
+        isPublishedFinancialOffer(financialOfferId) ||
+        isDealerForFinancialOffer(financialOfferId)
+      );
+    }
+
+    function negotiationThreadExists(negotiationThreadId) {
+      return exists(/databases/$(database)/documents/negotiationThreads/$(negotiationThreadId));
+    }
+
+    function negotiationThreadOfferId(negotiationThreadId) {
+      return negotiationThreadExists(negotiationThreadId)
+        ? get(/databases/$(database)/documents/negotiationThreads/$(negotiationThreadId)).data.financialOfferId
+        : negotiationThreadId;
+    }
+
+    function canAccessNegotiationThread(negotiationThreadId) {
+      return canAccessFinancialOffer(negotiationThreadOfferId(negotiationThreadId));
+    }
+
+    function dealerOwnsNegotiationThread(negotiationThreadId, dealerId) {
+      return matchesOfferDealer(negotiationThreadOfferId(negotiationThreadId), dealerId);
+    }
+
+    function isValidMessageAuthor(negotiationThreadId) {
+      return (
+        request.resource.data.authorRole == 'customer' &&
+        (
+          request.auth == null ||
+          !dealerOwnsNegotiationThread(negotiationThreadId, request.auth.uid)
+        )
+      ) || (
+        request.resource.data.authorRole == 'dealer' &&
+        request.auth != null &&
+        request.resource.data.authorId == request.auth.uid &&
+        dealerOwnsNegotiationThread(negotiationThreadId, request.auth.uid)
+      );
     }
   }
 }

--- a/src/components/checkout/PrequalDialog.tsx
+++ b/src/components/checkout/PrequalDialog.tsx
@@ -89,17 +89,22 @@ export function PrequalDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl overflow-hidden">
-        <DialogHeader>
-          <DialogTitle>Get prequalified</DialogTitle>
-          <DialogDescription>
-            Provide a few details so we can tee up a personalized credit pre-qualification. This will initiate a soft pull only.
-          </DialogDescription>
-        </DialogHeader>
-        <Form {...form}>
-          <form className="space-y-4" onSubmit={form.handleSubmit(handleSubmit)} noValidate>
-            <ScrollArea className="max-h-[60vh] pr-4">
-              <div className="space-y-6 pb-4">
+      <DialogContent className="sm:max-w-3xl max-h-[85vh] overflow-hidden p-0">
+        <div className="flex h-full flex-col">
+          <DialogHeader className="space-y-2 px-6 pt-6">
+            <DialogTitle>Get prequalified</DialogTitle>
+            <DialogDescription>
+              Provide a few details so we can tee up a personalized credit pre-qualification. This will initiate a soft pull only.
+            </DialogDescription>
+          </DialogHeader>
+          <Form {...form}>
+            <form
+              className="flex flex-1 flex-col gap-4 px-6 pb-6"
+              onSubmit={form.handleSubmit(handleSubmit)}
+              noValidate
+            >
+              <ScrollArea className="flex-1 -mr-4 pr-4">
+                <div className="space-y-6 pb-4">
                 <div className="grid gap-4 md:grid-cols-2">
                   <FormField
                     control={form.control}
@@ -314,28 +319,34 @@ export function PrequalDialog({
                   )}
                 />
               </div>
-            </ScrollArea>
+              </ScrollArea>
 
-            <p className="text-xs text-muted-foreground">
-              By submitting this form you acknowledge that we will acquire your credit report for pre-qualification.
-            </p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                By submitting this form you acknowledge that we will acquire your credit report for pre-qualification.
+              </p>
 
-            <div className="flex justify-end gap-2">
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? (
-                  <span className="flex items-center gap-2">
-                    <Loader2 className="h-4 w-4 animate-spin" /> Submitting…
-                  </span>
-                ) : (
-                  'Submit and run soft pull'
-                )}
-              </Button>
-            </div>
-          </form>
-        </Form>
+              <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-end sm:gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                  className="sm:min-w-[120px]"
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isSubmitting} className="sm:min-w-[180px]">
+                  {isSubmitting ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Submitting…
+                    </span>
+                  ) : (
+                    'Submit and run soft pull'
+                  )}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/model-match-quiz/QuizResults.tsx
+++ b/src/components/model-match-quiz/QuizResults.tsx
@@ -29,7 +29,7 @@ export function QuizResults({ results, onSelectVehicle, onRestart }: QuizResults
           <Card key={model.modelName} className="flex flex-col overflow-hidden hover:shadow-2xl transition-shadow duration-300 group">
             <CardHeader className="p-0">
                 <div className='bg-primary/10 p-4'>
-                    <p className="text-primary font-semibold text-center">"{model.rationale}"</p>
+                    <p className="text-primary font-semibold text-center">{model.rationale}</p>
                 </div>
               <div className="relative h-48 w-full">
                 <Image


### PR DESCRIPTION
## Summary
- relax negotiation thread and message rules so published offers can be accessed without authentication while keeping dealer-only metadata constraints
- add helper predicates that differentiate dealer ownership from public availability and reuse them across negotiation endpoints
- limit financial offer history access to authenticated dealers only to avoid exposing audit events to customers

## Testing
- not run (lint command prompts for interactive setup)

------
https://chatgpt.com/codex/tasks/task_e_68f4c236a88c832ca33dd5aad051bcac