### PR TITLE
Revamp saved scenario comparison flow and support guest negotiations

### DIFF
--- a/src/components/checkout/PrequalDialog.tsx
+++ b/src/components/checkout/PrequalDialog.tsx
@@ -76,6 +76,9 @@ export function PrequalDialog({
   initialValues,
 }: PrequalDialogProps) {
   const values = useMemo(() => initialValues ?? defaultPrequalValues, [initialValues]);
+  const labelClass = 'text-[11px] font-semibold uppercase tracking-wide text-muted-foreground';
+  const inputClass = 'h-9 text-sm';
+  const sectionSpacing = 'space-y-5';
 
   const form = useForm<PrequalFormValues>({
     resolver: zodResolver(prequalSchema),
@@ -91,29 +94,29 @@ export function PrequalDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-3xl max-h-[85vh] overflow-hidden p-0">
         <div className="flex h-full flex-col">
-          <DialogHeader className="space-y-2 px-6 pt-6">
-            <DialogTitle>Get prequalified</DialogTitle>
-            <DialogDescription>
-              Provide a few details so we can tee up a personalized credit pre-qualification. This will initiate a soft pull only.
+          <DialogHeader className="space-y-1.5 px-5 pt-5 pb-4">
+            <DialogTitle className="text-xl font-semibold">Get prequalified</DialogTitle>
+            <DialogDescription className="text-sm leading-relaxed text-muted-foreground">
+              Share a few essentials for a personalized credit preview. We&apos;ll keep it light and run a soft pull only.
             </DialogDescription>
           </DialogHeader>
           <Form {...form}>
             <form
-              className="flex flex-1 flex-col gap-4 px-6 pb-6"
+              className="flex flex-1 flex-col gap-3 px-5 pb-5"
               onSubmit={form.handleSubmit(handleSubmit)}
               noValidate
             >
-              <ScrollArea className="flex-1 -mr-4 pr-4">
-                <div className="space-y-6 pb-4">
-                <div className="grid gap-4 md:grid-cols-2">
+              <ScrollArea className="flex-1 pr-3">
+                <div className={`${sectionSpacing} pb-3`}>
+                <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
                   <FormField
                     control={form.control}
                     name="firstName"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>First name</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>First name</FormLabel>
                         <FormControl>
-                          <Input {...field} autoComplete="given-name" />
+                          <Input {...field} autoComplete="given-name" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -123,10 +126,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="lastName"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Last name</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>Last name</FormLabel>
                         <FormControl>
-                          <Input {...field} autoComplete="family-name" />
+                          <Input {...field} autoComplete="family-name" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -136,10 +139,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="email"
                     render={({ field }) => (
-                      <FormItem className="md:col-span-2">
-                        <FormLabel>Email</FormLabel>
+                      <FormItem className="md:col-span-2 lg:col-span-3 space-y-1.5">
+                        <FormLabel className={labelClass}>Email</FormLabel>
                         <FormControl>
-                          <Input {...field} type="email" autoComplete="email" />
+                          <Input {...field} type="email" autoComplete="email" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -149,10 +152,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="phone"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Phone</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>Phone</FormLabel>
                         <FormControl>
-                          <Input {...field} autoComplete="tel" />
+                          <Input {...field} autoComplete="tel" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -162,10 +165,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="dob"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Date of birth</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>Date of birth</FormLabel>
                         <FormControl>
-                          <Input {...field} type="date" />
+                          <Input {...field} type="date" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -175,10 +178,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="ssnLast4"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>SSN (last 4)</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>SSN (last 4)</FormLabel>
                         <FormControl>
-                          <Input {...field} inputMode="numeric" autoComplete="off" />
+                          <Input {...field} inputMode="numeric" autoComplete="off" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -188,10 +191,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="street"
                     render={({ field }) => (
-                      <FormItem className="md:col-span-2">
-                        <FormLabel>Street address</FormLabel>
+                      <FormItem className="md:col-span-2 lg:col-span-3 space-y-1.5">
+                        <FormLabel className={labelClass}>Street address</FormLabel>
                         <FormControl>
-                          <Input {...field} autoComplete="address-line1" />
+                          <Input {...field} autoComplete="address-line1" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -201,10 +204,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="city"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>City</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>City</FormLabel>
                         <FormControl>
-                          <Input {...field} autoComplete="address-level2" />
+                          <Input {...field} autoComplete="address-level2" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -214,10 +217,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="state"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>State</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>State</FormLabel>
                         <FormControl>
-                          <Input {...field} maxLength={2} autoComplete="address-level1" />
+                          <Input {...field} maxLength={2} autoComplete="address-level1" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -227,10 +230,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="zip"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>ZIP</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>ZIP</FormLabel>
                         <FormControl>
-                          <Input {...field} inputMode="numeric" autoComplete="postal-code" />
+                          <Input {...field} inputMode="numeric" autoComplete="postal-code" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -240,11 +243,11 @@ export function PrequalDialog({
                     control={form.control}
                     name="employmentStatus"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Employment status</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>Employment status</FormLabel>
                         <Select onValueChange={field.onChange} value={field.value}>
                           <FormControl>
-                            <SelectTrigger>
+                            <SelectTrigger className={inputClass}>
                               <SelectValue placeholder="Select status" />
                             </SelectTrigger>
                           </FormControl>
@@ -264,10 +267,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="monthlyIncome"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Monthly gross income</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>Monthly gross income</FormLabel>
                         <FormControl>
-                          <Input {...field} inputMode="decimal" placeholder="$7,500" />
+                          <Input {...field} inputMode="decimal" placeholder="$7,500" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -277,10 +280,10 @@ export function PrequalDialog({
                     control={form.control}
                     name="housingPayment"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Monthly housing payment</FormLabel>
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className={labelClass}>Monthly housing payment</FormLabel>
                         <FormControl>
-                          <Input {...field} inputMode="decimal" placeholder="$2,100" />
+                          <Input {...field} inputMode="decimal" placeholder="$2,100" className={inputClass} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -290,10 +293,15 @@ export function PrequalDialog({
                     control={form.control}
                     name="notes"
                     render={({ field }) => (
-                      <FormItem className="md:col-span-2">
-                        <FormLabel>Notes for the dealer (optional)</FormLabel>
+                      <FormItem className="md:col-span-2 lg:col-span-3 space-y-1.5">
+                        <FormLabel className={labelClass}>Notes for the dealer (optional)</FormLabel>
                         <FormControl>
-                          <Textarea {...field} rows={3} placeholder="Share any context about your credit or employment." />
+                          <Textarea
+                            {...field}
+                            rows={2}
+                            placeholder="Share any helpful context about your credit or employment."
+                            className="min-h-[72px] text-sm"
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -305,12 +313,12 @@ export function PrequalDialog({
                   control={form.control}
                   name="consent"
                   render={({ field }) => (
-                    <FormItem>
+                    <FormItem className="space-y-1.5">
                       <div className="flex items-start space-x-2">
                         <FormControl>
-                          <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                          <Checkbox checked={field.value} onCheckedChange={field.onChange} className="mt-0.5" />
                         </FormControl>
-                        <FormLabel className="text-sm font-normal">
+                        <FormLabel className="text-xs font-medium text-muted-foreground">
                           I authorize the dealer to obtain my credit report for pre-qualification purposes.
                         </FormLabel>
                       </div>
@@ -321,11 +329,11 @@ export function PrequalDialog({
               </div>
               </ScrollArea>
 
-              <p className="text-xs text-muted-foreground leading-relaxed">
+              <p className="text-[11px] leading-relaxed text-muted-foreground">
                 By submitting this form you acknowledge that we will acquire your credit report for pre-qualification.
               </p>
 
-              <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-end sm:gap-2">
+              <div className="flex flex-col gap-2 border-t pt-3 sm:flex-row sm:items-center sm:justify-end sm:gap-2">
                 <Button
                   type="button"
                   variant="outline"

--- a/src/components/finance-navigator/SavedScenariosDialog.tsx
+++ b/src/components/finance-navigator/SavedScenariosDialog.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
+import { Checkbox } from '@/components/ui/checkbox';
 import { formatCurrency, cn } from '@/lib/utils';
 import { useScenario } from '@/hooks/use-scenario';
 import { useToast } from '@/hooks/use-toast';
@@ -25,6 +26,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 interface SavedScenariosDialogProps {
   open: boolean;
@@ -35,6 +37,7 @@ export function SavedScenariosDialog({ open, onOpenChange }: SavedScenariosDialo
   const { savedScenarios, applySavedScenario, removeSavedScenario } = useScenario();
   const { toast } = useToast();
   const [selectedScenarioIds, setSelectedScenarioIds] = useState<string[]>([]);
+  const [isCompareMode, setIsCompareMode] = useState(false);
 
   const formatter = useMemo(
     () =>
@@ -59,6 +62,12 @@ export function SavedScenariosDialog({ open, onOpenChange }: SavedScenariosDialo
     );
   }, [savedScenarios]);
 
+  useEffect(() => {
+    if (isCompareMode && selectedScenarios.length < 2) {
+      setIsCompareMode(false);
+    }
+  }, [isCompareMode, selectedScenarios.length]);
+
   const selectedScenarios = useMemo(
     () =>
       selectedScenarioIds
@@ -66,6 +75,56 @@ export function SavedScenariosDialog({ open, onOpenChange }: SavedScenariosDialo
         .filter((value): value is typeof savedScenarios[number] => Boolean(value)),
     [selectedScenarioIds, savedScenarios],
   );
+
+  const handleDialogChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setIsCompareMode(false);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const bestValues = useMemo(() => {
+    if (selectedScenarios.length === 0) {
+      return {
+        monthly: undefined,
+        due: undefined,
+        total: undefined,
+        term: undefined,
+        down: undefined,
+        msrp: undefined,
+      } as const;
+    }
+
+    const normalize = (value: number) => Number(value.toFixed(2));
+
+    const monthlyValues = selectedScenarios.map((scenario) => normalize(scenario.monthlyPayment));
+    const dueValues = selectedScenarios.map((scenario) => normalize(scenario.dueAtSigning));
+    const totalValues = selectedScenarios.map((scenario) => normalize(scenario.totalCost));
+    const downValues = selectedScenarios.map((scenario) =>
+      normalize(scenario.scenario.downPayment + scenario.scenario.tradeInValue),
+    );
+    const msrpValues = selectedScenarios.map((scenario) => normalize(scenario.vehicle.msrp));
+
+    return {
+      monthly: Math.min(...monthlyValues),
+      due: Math.min(...dueValues),
+      total: Math.min(...totalValues),
+      term: Math.max(...selectedScenarios.map((scenario) => scenario.termMonths)),
+      down: Math.min(...downValues),
+      msrp: Math.min(...msrpValues),
+    } as const;
+  }, [selectedScenarios]);
+
+  const highlightClass = (value: number | undefined, best: number | undefined) => {
+    if (value === undefined || best === undefined) return '';
+    const normalizedValue = Number(value.toFixed(2));
+    const normalizedBest = Number(best.toFixed(2));
+    return Math.abs(normalizedValue - normalizedBest) < 0.01
+      ? 'bg-emerald-50 text-emerald-700 font-semibold'
+      : '';
+  };
+
+  const compareDisabled = selectedScenarioIds.length < 2;
 
   const toggleScenarioSelection = (id: string) => {
     setSelectedScenarioIds((prev) => {
@@ -112,189 +171,313 @@ export function SavedScenariosDialog({ open, onOpenChange }: SavedScenariosDialo
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl">
-        <DialogHeader>
-          <DialogTitle className="font-headline text-2xl">Saved Scenarios</DialogTitle>
-          <DialogDescription>
-            Revisit quotes you&apos;ve bookmarked. Load one to update the navigator instantly or curate a new comparison.
-          </DialogDescription>
-        </DialogHeader>
-        {sortedScenarios.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-3 py-10 text-center text-sm text-muted-foreground">
-            <BookmarkCheck className="h-10 w-10 text-muted-foreground/70" />
-            <p>No saved scenarios yet.</p>
-            <p className="max-w-xs">
-              Compare finance and lease options, then use the save actions to capture the details for quick recall.
-            </p>
-          </div>
-        ) : (
-          <ScrollArea className="max-h-[60vh] pr-2">
-            <div className="space-y-4">
-              {sortedScenarios.map((item) => {
-                const isSelected = selectedScenarioIds.includes(item.id);
-                return (
-                  <Card
-                    key={item.id}
-                    className={cn(
-                      'shadow-sm transition',
-                      isSelected && 'ring-2 ring-primary/50',
-                    )}
-                  >
-                  <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="space-y-1">
-                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                        <Badge variant={item.planType === 'finance' ? 'default' : 'secondary'} className="uppercase tracking-wide">
-                          {item.planType === 'finance' ? 'Finance Plan' : 'Lease Plan'}
-                        </Badge>
-                        <span className="inline-flex items-center gap-1">
-                          <CalendarClock className="h-3.5 w-3.5" />
-                          {formatter.format(new Date(item.savedAt))}
-                        </span>
-                      </div>
-                      <CardTitle className="text-xl font-headline">{item.vehicle.modelName}</CardTitle>
-                      <CardDescription className="text-base">
-                        {formatCurrency(item.monthlyPayment)}/mo for {item.termMonths} months • Due today {formatCurrency(item.dueAtSigning)}
-                      </CardDescription>
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        variant={isSelected ? 'secondary' : 'outline'}
-                        onClick={() => toggleScenarioSelection(item.id)}
-                        className="font-medium"
-                      >
-                        {isSelected ? 'Selected' : 'Compare'}
-                      </Button>
-                      <Button variant="ghost" size="icon" onClick={() => handleRemove(item.id)} aria-label="Remove scenario">
-                        <BookmarkX className="h-4 w-4" />
-                      </Button>
-                      <Button onClick={() => handleApply(item.id)} className="font-medium">
-                        Load Scenario
-                      </Button>
-                    </div>
-                  </CardHeader>
-                  <Separator />
-                  <CardContent className="grid gap-4 pt-4 text-sm sm:grid-cols-2">
-                    <div className="space-y-1">
-                      <p className="text-muted-foreground">Vehicle MSRP</p>
-                      <p className="font-medium">{formatCurrency(item.vehicle.msrp)}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-muted-foreground">Total Paid</p>
-                      <p className="font-medium">{formatCurrency(item.totalCost)}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-muted-foreground">Down + Trade Equity</p>
-                      <p className="font-medium">{formatCurrency(item.scenario.downPayment + item.scenario.tradeInValue)}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-muted-foreground">Credit Tier</p>
-                      <p className="font-medium">{item.scenario.creditScoreTier}</p>
-                    </div>
-                    <div className="sm:col-span-2 space-y-1">
-                      <p className="text-muted-foreground">Snapshot</p>
-                      <p>
-                        {item.vehicle.keySpecs}
-                      </p>
-                    </div>
-                  </CardContent>
-                </Card>
-                );
-              })}
-            </div>
-          </ScrollArea>
+    <Dialog open={open} onOpenChange={handleDialogChange}>
+      <DialogContent
+        className={cn(
+          isCompareMode ? 'sm:max-w-5xl lg:max-w-6xl' : 'sm:max-w-3xl',
+          'space-y-4',
         )}
-        {selectedScenarios.length >= 2 && (
-          <div className="mt-6 space-y-4">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <h3 className="font-headline text-xl">Compare selected scenarios</h3>
-                <p className="text-sm text-muted-foreground">
-                  Review the highlights of each option side-by-side before deciding which one to load.
+      >
+        {isCompareMode ? (
+          <>
+            <DialogHeader className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <DialogTitle className="font-headline text-2xl">Compare scenarios</DialogTitle>
+                  <DialogDescription>
+                    Stack your saved quotes across key cost, term, and vehicle metrics. Highlighted cells call out the leader.
+                  </DialogDescription>
+                </div>
+                <Button
+                  variant="ghost"
+                  onClick={() => setIsCompareMode(false)}
+                  className="self-start sm:self-auto"
+                >
+                  Back to saved scenarios
+                </Button>
+              </div>
+            </DialogHeader>
+            <Tabs defaultValue="costs" className="space-y-4">
+              <TabsList className="grid gap-2 bg-muted/60 p-1 sm:max-w-md sm:grid-cols-3">
+                <TabsTrigger value="costs">Costs</TabsTrigger>
+                <TabsTrigger value="terms">Terms</TabsTrigger>
+                <TabsTrigger value="vehicle">Vehicle</TabsTrigger>
+              </TabsList>
+              <TabsContent value="costs" className="space-y-3">
+                <div className="overflow-x-auto rounded-lg border bg-background">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="min-w-[220px]">Scenario</TableHead>
+                        <TableHead>Monthly payment</TableHead>
+                        <TableHead>Due at signing</TableHead>
+                        <TableHead>Total paid</TableHead>
+                        <TableHead className="text-right">Action</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {selectedScenarios.map((scenario) => (
+                        <TableRow key={scenario.id}>
+                          <TableCell>
+                            <div className="flex flex-col gap-1">
+                              <span className="font-semibold">{scenario.vehicle.modelName}</span>
+                              <Badge
+                                variant={scenario.planType === 'finance' ? 'default' : 'secondary'}
+                                className="w-max uppercase"
+                              >
+                                {scenario.planType === 'finance' ? 'Finance' : 'Lease'}
+                              </Badge>
+                            </div>
+                          </TableCell>
+                          <TableCell
+                            className={cn(
+                              'font-semibold',
+                              highlightClass(scenario.monthlyPayment, bestValues.monthly),
+                            )}
+                          >
+                            {formatCurrency(scenario.monthlyPayment)}
+                          </TableCell>
+                          <TableCell className={highlightClass(scenario.dueAtSigning, bestValues.due)}>
+                            {formatCurrency(scenario.dueAtSigning)}
+                          </TableCell>
+                          <TableCell className={highlightClass(scenario.totalCost, bestValues.total)}>
+                            {formatCurrency(scenario.totalCost)}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button size="sm" onClick={() => handleApply(scenario.id)}>
+                              Load scenario
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </TabsContent>
+              <TabsContent value="terms" className="space-y-3">
+                <div className="overflow-x-auto rounded-lg border bg-background">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="min-w-[220px]">Scenario</TableHead>
+                        <TableHead>Plan type</TableHead>
+                        <TableHead>Term length</TableHead>
+                        <TableHead>Credit tier</TableHead>
+                        <TableHead>Down + trade</TableHead>
+                        <TableHead className="text-right">Action</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {selectedScenarios.map((scenario) => {
+                        const combinedDown = scenario.scenario.downPayment + scenario.scenario.tradeInValue;
+                        return (
+                          <TableRow key={`${scenario.id}-terms`}>
+                            <TableCell>
+                              <div className="flex flex-col gap-1">
+                                <span className="font-semibold">{scenario.vehicle.modelName}</span>
+                                <span className="text-xs text-muted-foreground">
+                                  Saved {formatter.format(new Date(scenario.savedAt))}
+                                </span>
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <Badge
+                                variant={scenario.planType === 'finance' ? 'default' : 'secondary'}
+                                className="w-max uppercase"
+                              >
+                                {scenario.planType === 'finance' ? 'Finance' : 'Lease'}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className={highlightClass(scenario.termMonths, bestValues.term)}>
+                              {scenario.termMonths} months
+                            </TableCell>
+                            <TableCell>{scenario.scenario.creditScoreTier}</TableCell>
+                            <TableCell className={highlightClass(combinedDown, bestValues.down)}>
+                              {formatCurrency(combinedDown)}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <Button size="sm" onClick={() => handleApply(scenario.id)}>
+                                Load scenario
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
+              </TabsContent>
+              <TabsContent value="vehicle" className="space-y-3">
+                <div className="overflow-x-auto rounded-lg border bg-background">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="min-w-[220px]">Scenario</TableHead>
+                        <TableHead>Vehicle MSRP</TableHead>
+                        <TableHead>Vehicle highlights</TableHead>
+                        <TableHead className="text-right">Action</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {selectedScenarios.map((scenario) => (
+                        <TableRow key={`${scenario.id}-vehicle`}>
+                          <TableCell>
+                            <div className="flex flex-col gap-1">
+                              <span className="font-semibold">{scenario.vehicle.modelName}</span>
+                              <span className="text-xs text-muted-foreground">
+                                {formatCurrency(scenario.monthlyPayment)}/mo • {scenario.termMonths} months
+                              </span>
+                            </div>
+                          </TableCell>
+                          <TableCell className={highlightClass(scenario.vehicle.msrp, bestValues.msrp)}>
+                            {formatCurrency(scenario.vehicle.msrp)}
+                          </TableCell>
+                          <TableCell className="text-sm text-muted-foreground">
+                            {scenario.vehicle.keySpecs}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button size="sm" onClick={() => handleApply(scenario.id)}>
+                              Load scenario
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </TabsContent>
+            </Tabs>
+          </>
+        ) : (
+          <>
+            <DialogHeader className="space-y-3">
+              <DialogTitle className="font-headline text-2xl">Saved Scenarios</DialogTitle>
+              <DialogDescription>
+                Revisit quotes you&apos;ve bookmarked. Load one instantly or choose up to three to compare.
+              </DialogDescription>
+            </DialogHeader>
+            {sortedScenarios.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-10 text-center text-sm text-muted-foreground">
+                <BookmarkCheck className="h-10 w-10 text-muted-foreground/70" />
+                <p>No saved scenarios yet.</p>
+                <p className="max-w-xs">
+                  Compare finance and lease options, then use the save actions to capture the details for quick recall.
                 </p>
               </div>
-              <Button variant="ghost" onClick={() => setSelectedScenarioIds([])} className="self-start sm:self-auto">
-                Clear selection
-              </Button>
-            </div>
-            <div className="overflow-x-auto rounded-lg border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-40">Metric</TableHead>
-                    {selectedScenarios.map((scenario) => (
-                      <TableHead key={scenario.id} className="min-w-[160px]">
-                        <div className="flex flex-col gap-1">
-                          <span className="font-semibold">{scenario.vehicle.modelName}</span>
-                          <Badge variant={scenario.planType === 'finance' ? 'default' : 'secondary'} className="w-max uppercase">
-                            {scenario.planType === 'finance' ? 'Finance' : 'Lease'}
-                          </Badge>
-                        </div>
-                      </TableHead>
-                    ))}
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  <TableRow>
-                    <TableCell className="font-medium">Monthly payment</TableCell>
-                    {selectedScenarios.map((scenario) => (
-                      <TableCell key={`${scenario.id}-monthly`} className="font-semibold">
-                        {formatCurrency(scenario.monthlyPayment)}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                  <TableRow>
-                    <TableCell className="font-medium">Due at signing</TableCell>
-                    {selectedScenarios.map((scenario) => (
-                      <TableCell key={`${scenario.id}-due`}>
-                        {formatCurrency(scenario.dueAtSigning)}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                  <TableRow>
-                    <TableCell className="font-medium">Term length</TableCell>
-                    {selectedScenarios.map((scenario) => (
-                      <TableCell key={`${scenario.id}-term`}>
-                        {scenario.termMonths} months
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                  <TableRow>
-                    <TableCell className="font-medium">Total paid</TableCell>
-                    {selectedScenarios.map((scenario) => (
-                      <TableCell key={`${scenario.id}-total`}>
-                        {formatCurrency(scenario.totalCost)}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                  <TableRow>
-                    <TableCell className="font-medium">Down + trade equity</TableCell>
-                    {selectedScenarios.map((scenario) => (
-                      <TableCell key={`${scenario.id}-down`}>
-                        {formatCurrency(scenario.scenario.downPayment + scenario.scenario.tradeInValue)}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                  <TableRow>
-                    <TableCell className="font-medium">Credit tier</TableCell>
-                    {selectedScenarios.map((scenario) => (
-                      <TableCell key={`${scenario.id}-tier`}>
-                        {scenario.scenario.creditScoreTier}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                  <TableRow>
-                    <TableCell className="font-medium">Saved on</TableCell>
-                    {selectedScenarios.map((scenario) => (
-                      <TableCell key={`${scenario.id}-saved`}>
-                        {formatter.format(new Date(scenario.savedAt))}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </div>
-          </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex flex-col gap-3 rounded-md border border-dashed border-muted-foreground/40 bg-muted/30 p-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-medium">Select scenarios to compare</p>
+                    <p className="text-xs text-muted-foreground">
+                      Choose up to three saved scenarios. You currently have {selectedScenarioIds.length} selected.
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                    <Button
+                      variant="ghost"
+                      disabled={selectedScenarioIds.length === 0}
+                      onClick={() => setSelectedScenarioIds([])}
+                    >
+                      Clear selection
+                    </Button>
+                    <Button
+                      onClick={() => setIsCompareMode(true)}
+                      disabled={compareDisabled}
+                      className="sm:min-w-[160px]"
+                    >
+                      Compare selected ({selectedScenarioIds.length || 0})
+                    </Button>
+                  </div>
+                </div>
+                <ScrollArea className="max-h-[60vh] pr-2">
+                  <div className="space-y-3">
+                    {sortedScenarios.map((item) => {
+                      const isSelected = selectedScenarioIds.includes(item.id);
+                      const downTotal = item.scenario.downPayment + item.scenario.tradeInValue;
+                      return (
+                        <Card
+                          key={item.id}
+                          className={cn(
+                            'shadow-sm transition',
+                            isSelected && 'ring-2 ring-primary/60',
+                          )}
+                        >
+                          <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                            <div className="flex w-full gap-3">
+                              <Checkbox
+                                checked={isSelected}
+                                onCheckedChange={() => toggleScenarioSelection(item.id)}
+                                aria-label={`Select ${item.vehicle.modelName} scenario`}
+                                className="mt-1 shrink-0"
+                              />
+                              <div className="space-y-2">
+                                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                  <Badge
+                                    variant={item.planType === 'finance' ? 'default' : 'secondary'}
+                                    className="uppercase tracking-wide"
+                                  >
+                                    {item.planType === 'finance' ? 'Finance Plan' : 'Lease Plan'}
+                                  </Badge>
+                                  <span className="inline-flex items-center gap-1">
+                                    <CalendarClock className="h-3.5 w-3.5" />
+                                    {formatter.format(new Date(item.savedAt))}
+                                  </span>
+                                </div>
+                                <CardTitle className="text-xl font-headline">{item.vehicle.modelName}</CardTitle>
+                                <CardDescription className="text-sm">
+                                  {formatCurrency(item.monthlyPayment)}/mo · {item.termMonths} months · Due today {formatCurrency(item.dueAtSigning)}
+                                </CardDescription>
+                              </div>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                variant={isSelected ? 'default' : 'outline'}
+                                onClick={() => toggleScenarioSelection(item.id)}
+                                className="font-medium"
+                              >
+                                {isSelected ? 'Selected' : 'Compare'}
+                              </Button>
+                              <Button variant="outline" onClick={() => handleApply(item.id)} className="font-medium">
+                                Load
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRemove(item.id)}
+                                aria-label="Remove scenario"
+                              >
+                                <BookmarkX className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          </CardHeader>
+                          <Separator />
+                          <CardContent className="grid gap-3 bg-muted/20 p-4 text-xs sm:grid-cols-3">
+                            <div className="space-y-1">
+                              <p className="text-muted-foreground">Vehicle MSRP</p>
+                              <p className="font-semibold">{formatCurrency(item.vehicle.msrp)}</p>
+                            </div>
+                            <div className="space-y-1">
+                              <p className="text-muted-foreground">Down + trade</p>
+                              <p className="font-semibold">{formatCurrency(downTotal)}</p>
+                            </div>
+                            <div className="space-y-1">
+                              <p className="text-muted-foreground">Credit tier</p>
+                              <p className="font-semibold">{item.scenario.creditScoreTier}</p>
+                            </div>
+                            <div className="sm:col-span-3 space-y-1">
+                              <p className="text-muted-foreground">Snapshot</p>
+                              <p className="text-sm leading-relaxed">{item.vehicle.keySpecs}</p>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      );
+                    })}
+                  </div>
+                </ScrollArea>
+              </div>
+            )}
+          </>
         )}
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- allow negotiation threads to capture guest participation by persisting a local customer identifier and no longer requiring sign-in
- slim down the prequalification form spacing and control sizing so the panel fits without scrolling
- redesign the saved scenario dialog to use checkbox selection and a dedicated comparison modal with tabbed metrics and load actions

## Testing
- npm run lint *(fails: command prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68f4c8bca47c832cb62bed62c3124346