### PR TITLE
Allow authenticated access to offer purchases

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -90,6 +90,18 @@ service cloud.firestore {
     }
 
     /**
+     * @description Allows authenticated users to store and retrieve offer purchase records.
+     * @path /offerPurchases/{purchaseId}
+     * @allow (get, list, create, update, delete): if isSignedIn();
+     * @principle Purchases recorded during checkout must be available to authorized application users.
+     */
+    match /offerPurchases/{purchaseId} {
+      allow get, list: if isSignedIn();
+      allow create: if isSignedIn();
+      allow update, delete: if isSignedIn();
+    }
+
+    /**
      * @description Allows users to manage their income verification data.
      * @path /users/{userId}/incomeVerifications/{incomeVerificationId}
      * @allow (get, list, create, update, delete): if isOwner(userId);

--- a/src/components/checkout/CheckoutProvider.tsx
+++ b/src/components/checkout/CheckoutProvider.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import { FinancialOffer } from '@/types';
+import type { PrequalFormValues } from './PrequalDialog';
 import { useSearchParams } from 'next/navigation';
 
 // Mock data imports - in a real app, this would be fetched from an API
@@ -28,10 +29,19 @@ interface CheckoutState {
   tradeInValue: number;
   availableAddons: Addon[];
   selectedAddons: string[];
+  selectedAddonDetails: Addon[];
   toggleAddon: (id: string) => void;
   totalAddonsPrice: number;
   totalAmount: number;
   amountDueAtSigning: number;
+  prequalSubmission: PrequalFormValues | null;
+  setPrequalSubmission: (values: PrequalFormValues | null) => void;
+  paymentContact: { email: string; name: string } | null;
+  setPaymentContact: (contact: { email: string; name: string } | null) => void;
+  appointment: { method: 'pickup' | 'delivery'; date: Date | null; timeSlot: string | null } | null;
+  setAppointment: (
+    details: { method: 'pickup' | 'delivery'; date: Date | null; timeSlot: string | null } | null,
+  ) => void;
 }
 
 const CheckoutContext = createContext<CheckoutState | undefined>(undefined);
@@ -73,6 +83,13 @@ export function CheckoutProvider({ children }: { children: ReactNode }) {
   const [tradeInValue] = useState<number>(mockTradeIn.estimate);
   const [availableAddons] = useState<Addon[]>(mockAddons);
   const [selectedAddons, setSelectedAddons] = useState<string[]>([]);
+  const [prequalSubmission, setPrequalSubmission] = useState<PrequalFormValues | null>(null);
+  const [paymentContact, setPaymentContact] = useState<{ email: string; name: string } | null>(null);
+  const [appointment, setAppointment] = useState<{
+    method: 'pickup' | 'delivery';
+    date: Date | null;
+    timeSlot: string | null;
+  } | null>(null);
 
   const toggleAddon = useCallback((id: string) => {
     setSelectedAddons((prev) =>
@@ -80,13 +97,19 @@ export function CheckoutProvider({ children }: { children: ReactNode }) {
     );
   }, []);
 
-  const totalAddonsPrice = useMemo(() =>
-    availableAddons.reduce(
-      (total, addon) =>
-        selectedAddons.includes(addon.id) ? total + addon.price : total,
-      0,
-    ),
+  const totalAddonsPrice = useMemo(
+    () =>
+      availableAddons.reduce(
+        (total, addon) =>
+          selectedAddons.includes(addon.id) ? total + addon.price : total,
+        0,
+      ),
     [selectedAddons, availableAddons],
+  );
+
+  const selectedAddonDetails = useMemo(
+    () => availableAddons.filter((addon) => selectedAddons.includes(addon.id)),
+    [availableAddons, selectedAddons],
   );
 
   const totalAmount = useMemo(
@@ -107,9 +130,16 @@ export function CheckoutProvider({ children }: { children: ReactNode }) {
       availableAddons,
       selectedAddons,
       toggleAddon,
+      selectedAddonDetails,
       totalAddonsPrice,
       totalAmount,
       amountDueAtSigning,
+      prequalSubmission,
+      setPrequalSubmission,
+      paymentContact,
+      setPaymentContact,
+      appointment,
+      setAppointment,
     }),
     [
       offer,
@@ -117,9 +147,13 @@ export function CheckoutProvider({ children }: { children: ReactNode }) {
       availableAddons,
       selectedAddons,
       toggleAddon,
+      selectedAddonDetails,
       totalAddonsPrice,
       totalAmount,
       amountDueAtSigning,
+      prequalSubmission,
+      paymentContact,
+      appointment,
     ],
   );
 

--- a/src/components/checkout/CreditApplicationFlow.tsx
+++ b/src/components/checkout/CreditApplicationFlow.tsx
@@ -25,6 +25,7 @@ import type { MockCreditReport, VerificationStatus } from '@/types';
 import { Loader2, ShieldCheck } from 'lucide-react';
 import { format } from 'date-fns';
 import { PrequalDialog, PrequalFormValues } from './PrequalDialog';
+import { useCheckout } from './CheckoutProvider';
 
 const statusVariants: Record<VerificationStatus, 'default' | 'secondary' | 'destructive'> = {
   Pending: 'secondary',
@@ -52,7 +53,7 @@ export function CreditApplicationFlow() {
   const [error, setError] = useState<string | null>(null);
   const [isPrequalOpen, setIsPrequalOpen] = useState(false);
   const [isSubmittingPrequal, setIsSubmittingPrequal] = useState(false);
-  const [prequalSubmission, setPrequalSubmission] = useState<PrequalFormValues | null>(null);
+  const { prequalSubmission, setPrequalSubmission } = useCheckout();
 
   const runSoftPull = async () => {
     setIsPulling(true);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,37 @@ export interface FinancialOffer {
   vehicleDetails?: VehicleDetails;
 }
 
+export interface OfferPurchaseAddon {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export interface OfferPurchase {
+  id: string;
+  dealerId: string;
+  offerId: string;
+  vehicleModelName: string;
+  offerType: OfferType;
+  purchaseTotal: number;
+  amountDueAtSigning: number;
+  tradeInValue: number;
+  selectedAddons: OfferPurchaseAddon[];
+  customer: {
+    firstName?: string;
+    lastName?: string;
+    email: string;
+    phone?: string;
+  };
+  paymentContactName?: string | null;
+  appointment?: {
+    method: 'pickup' | 'delivery';
+    date?: string | null;
+    timeSlot?: string | null;
+  } | null;
+  purchasedAt: Date | Timestamp | FieldValue | { seconds: number; nanoseconds?: number };
+}
+
 export interface Vehicle {
   id: string;
   modelName: string;


### PR DESCRIPTION
## Summary
- add Firestore security rules to allow authenticated access to offer purchase documents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4cffcee88832c98cfe24f7e90aa95