### PR TITLE
Add placeholder vehicle URLs and sync quiz photo links

### DIFF
--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -6,6 +6,7 @@ const VehicleSchema = z.object({
     seating_capacity: z.number(),
     available_powertrains: z.array(z.string()),
     features: z.array(z.string()),
+    url: z.string(),
 });
 
 export const SuggestModelsFromQuizInputSchema = z.object({


### PR DESCRIPTION
## Summary
- assign distinct placeholder URLs to each quiz vehicle entry
- ensure the quiz flow reuses the vehicle URL for any recommended model photoUrl

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f521b33b04832c88e38c9a8159fb86